### PR TITLE
Set default transition time when initially connecting to Hue

### DIFF
--- a/devicetypes/info-fiend/ap-hue-bulb.src/ap-hue-bulb.groovy
+++ b/devicetypes/info-fiend/ap-hue-bulb.src/ap-hue-bulb.groovy
@@ -106,15 +106,13 @@ def parse(description) {
 void on() 
 {
 	def level = device.currentValue("level")
-    if(level == null)
-    {
+    if(level == null) {
     	level = 100
     }
 
 	def transitionTime = device.currentValue("transTime")
-    if(transitionTime == null)
-    {
-    	transitionTime = 3
+    if(transitionTime == null) {
+    	transitionTime = parent.getSelectedTransition()
     }
     
 //    log.debug this ": level = ${level} & tt= ${transitionTime}"
@@ -127,8 +125,7 @@ void on()
 void on(transitiontime)
 {
 	def level = device.currentValue("level")
-    if(level == null)
-    {
+    if(level == null) {
     	level = 100
     }
 	parent.on(this, transitiontime, level)
@@ -139,9 +136,8 @@ void on(transitiontime)
 void off() 
 {
 	def transitionTime = device.currentValue("transTime")
-    if(transitionTime == null)
-    {
-    	transitionTime = 3
+    if(transitionTime == null) {
+    	transitionTime = parent.getSelectedTransition()
     }
     
  //   log.debug this ": off & tt = ${transitionTime}"
@@ -166,17 +162,16 @@ void setTT(transitiontime) {
 }
 
 void setColorTemperature(colorTkelvin) {
-    if(colorTkelvin == null)
-    {
+    if(colorTkelvin == null) {
     	colorTkelvin = 2400
     }
     
     def transitionTime = device.currentValue("transTime")
     if(transitionTime == null) {
-    	transitionTime = 3
+    	transitionTime = parent.getSelectedTransition()
     }
     
-    def colorTmireks = kelvinToMireks(colorTkelvin)
+    def colorTmireks = parent.kelvinToMireks(colorTkelvin)
     
 	log.debug "Executing 'setColorTemperature'"
 	parent.setCT(this, colorTmireks, transitionTime)
@@ -186,12 +181,11 @@ void setColorTemperature(colorTkelvin) {
 }
 
 void setColorTemperature(colorTkelvin, transitiontime) {
-    if(colorTkelvin == null)
-    {
+    if(colorTkelvin == null) {
     	colorTkelvin = 2400
     }
     
-    def colorTmireks = kelvinToMireks(colorTkelvin)
+    def colorTmireks = parent.kelvinToMireks(colorTkelvin)
     
 	log.debug "Executing 'setColorTemperature'"
 	parent.setCT(this, colorTmireks, transitiontime)
@@ -220,13 +214,11 @@ void nextLevel() {
 
 void setLevel(percent) {
 	def transitionTime = device.currentValue("transTime")
-    if(transitionTime == null)
-    {
-    	transitionTime = 3
+    if(transitionTime == null) {
+    	transitionTime = parent.getSelectedTransition()
     }
         
-	if(device.latestValue("level") as Integer == 0)
-    (
+	if(device.latestValue("level") as Integer == 0) (
     	transitionTime = 0
     )
 	
@@ -251,9 +243,8 @@ void setLevel(percent, transitiontime) {
 void setSaturation(percent) 
 {
 	def transitionTime = device.currentValue("transTime")
-    if(transitionTime == null)
-    {
-    	transitionTime = 3
+    if(transitionTime == null) {
+    	transitionTime = parent.getSelectedTransition()
     }
     
  //   log.debug this ": tt= ${transitionTime}"
@@ -274,9 +265,8 @@ void setSaturation(percent, transitiontime)
 void setHue(percent) 
 {
 	def transitionTime = device.currentValue("transTime")
-    if(transitionTime == null)
-    {
-    	transitionTime = 3
+    if(transitionTime == null) {
+    	transitionTime = parent.getSelectedTransition()
     }
     
 //    log.debug this ": tt= ${transitionTime}"
@@ -307,9 +297,8 @@ void setColor(value) {
 	else
 	{
     	def transitionTime = device.currentValue("transTime")
-	    if(transitionTime == null)
-    	{
-    		transitionTime = 3
+	    if(transitionTime == null) {
+    		transitionTime = parent.getSelectedTransition()
 	    }
     
 //    	log.debug this ": tt= ${transitionTime}"
@@ -357,10 +346,6 @@ void setAdjustedColor(value) {
         adjusted.level = device.currentValue("level") // null 
         setColor(adjusted)
     }
-}
-
-int kelvinToMireks(kelvin) {
-	return 1000000 / kelvin //https://en.wikipedia.org/wiki/Mired
 }
 
 def adjustOutgoingHue(percent) {

--- a/devicetypes/info-fiend/ap-hue-group.src/ap-hue-group.groovy
+++ b/devicetypes/info-fiend/ap-hue-group.src/ap-hue-group.groovy
@@ -118,15 +118,13 @@ void setTT(transitiontime) {
 void on() 
 {
 	def level = device.currentValue("level")
-    if(level == null)
-    {
+    if(level == null) {
     	level = 100
     }
 	
     def transitionTime = device.currentValue("transTime")
-    if(transitionTime == null)
-    {
-    	transitionTime = 3
+    if(transitionTime == null) {
+    	transitionTime = parent.getSelectedTransition()
     }
 	parent.groupOn(this, transitionTime, level)
 	sendEvent(name: "switch", value: "on")
@@ -136,8 +134,7 @@ void on()
 void on(transitiontime)
 {
 	def level = device.currentValue("level")
-    if(level == null)
-    {
+    if(level == null) {
     	level = 100
     }
 	parent.groupOn(this, transitiontime, level)
@@ -148,9 +145,8 @@ void on(transitiontime)
 void off() 
 {
 	def transitionTime = device.currentValue("transTime")
-    if(transitionTime == null)
-    {
-    	transitionTime = 3
+    if(transitionTime == null) {
+    	transitionTime = parent.getSelectedTransition()
     }
 	parent.groupOff(this, transitionTime)
 	sendEvent(name: "switch", value: "off")
@@ -170,17 +166,16 @@ void poll() {
 
 
 void setColorTemperature(colorTkelvin) {
-    if(colorTkelvin == null)
-    {
+    if(colorTkelvin == null) {
     	colorTkelvin = 2400
     }
     
     def transitionTime = device.currentValue("transTime")
     if(transitionTime == null) {
-    	transitionTime = 3
+    	transitionTime = parent.getSelectedTransition()
     }
     
-    def colorTmireks = kelvinToMireks(colorTkelvin)
+    def colorTmireks = parent.kelvinToMireks(colorTkelvin)
     
 	log.debug "Executing 'setColorTemperature'"
 	parent.setGroupCT(this, colorTmireks, transitionTime)
@@ -190,12 +185,11 @@ void setColorTemperature(colorTkelvin) {
 }
 
 void setColorTemperature(colorTkelvin, transitiontime) {
-    if(colorTkelvin == null)
-    {
+    if(colorTkelvin == null) {
     	colorTkelvin = 2400
     }
         
-    def colorTmireks = kelvinToMireks(colorTkelvin)
+    def colorTmireks = parent.kelvinToMireks(colorTkelvin)
     
 	log.debug "Executing 'setColorTemperature'"
 	parent.setGroupCT(this, colorTmireks, transitiontime)
@@ -218,9 +212,8 @@ void nextLevel() {
 void setLevel(percent) 
 {
 	def transitionTime = device.currentValue("transTime")
-    if(transitionTime == null)
-    {
-    	transitionTime = 3
+    if(transitionTime == null) {
+    	transitionTime = parent.getSelectedTransition()
     }
 	log.debug "Executing 'setLevel'"
 	parent.setGroupLevel(this, percent, transitionTime)
@@ -239,9 +232,8 @@ void setLevel(percent, transitiontime)
 void setSaturation(percent) 
 {
 	def transitionTime = device.currentValue("transTime")
-    if(transitionTime == null)
-    {
-    	transitionTime = 3
+    if(transitionTime == null) {
+    	transitionTime = parent.getSelectedTransition()
     }
 	log.debug "Executing 'setSaturation'"
 	parent.setGroupSaturation(this, percent, transitionTime)
@@ -259,9 +251,8 @@ void setSaturation(percent, transitiontime)
 void setHue(percent) 
 {
 	def transitionTime = device.currentValue("transTime")
-    if(transitionTime == null)
-    {
-    	transitionTime = 3
+    if(transitionTime == null) {
+    	transitionTime = parent.getSelectedTransition()
     }
 	log.debug "Executing 'setHue'"
 	parent.setGroupHue(this, percent, transitionTime)
@@ -288,9 +279,8 @@ void setColor(value) {
 	else
 	{
 		def transitionTime = device.currentValue("transTime")
-	    if(transitionTime == null)
-    	{
-    		transitionTime = 3
+	    if(transitionTime == null) {
+    		transitionTime = parent.getSelectedTransition()
     	}
 		value << [transitiontime: transitionTime]
 	}
@@ -342,10 +332,6 @@ void setAdjustedColor(value) {
         adjusted.level = device.currentValue("level") // null 
         setColor(adjusted)
     }
-}
-
-int kelvinToMireks(kelvin) {
-	return 1000000 / kelvin //https://en.wikipedia.org/wiki/Mired
 }
 
 def adjustOutgoingHue(percent) {

--- a/devicetypes/info-fiend/ap-hue-lux-bulb.src/ap-hue-lux-bulb.groovy
+++ b/devicetypes/info-fiend/ap-hue-lux-bulb.src/ap-hue-lux-bulb.groovy
@@ -99,7 +99,7 @@ void on() {
     
 	def transitionTime = device.currentValue("transTime")
     if(transitionTime == null) {
-    	transitionTime = 3
+    	transitionTime = parent.getSelectedTransition()
     }
 	parent.on(this, transitionTime, level)
 	sendEvent(name: "switch", value: "on")
@@ -119,7 +119,7 @@ void on(transitiontime){
 void off() {
 	def transitionTime = device.currentValue("transTime")
     if(transitionTime == null) {
-    	transitionTime = 3
+    	transitionTime = parent.getSelectedTransition()
     }
     
 	parent.off(this, transitionTime)
@@ -145,7 +145,7 @@ def poll() {
 def setLevel(percent) {
 	def transitionTime = device.currentValue("transTime")
     if(transitionTime == null) {
-    	transitionTime = 3
+    	transitionTime = parent.getSelectedTransition()
     }
     
     if(device.latestValue("level") as Integer == 0) (

--- a/smartapps/info-fiend/hue-lights-and-groups-and-scenes-oh-my.src/hue-lights-and-groups-and-scenes-oh-my.groovy
+++ b/smartapps/info-fiend/hue-lights-and-groups-and-scenes-oh-my.src/hue-lights-and-groups-and-scenes-oh-my.groovy
@@ -25,6 +25,7 @@ preferences {
 	page(name:"bulbDiscovery", title:"Bulb Discovery", content:"bulbDiscovery", refreshTimeout:5)
 	page(name:"groupDiscovery", title:"Group Discovery", content:"groupDiscovery", refreshTimeout:5)        
 	page(name:"sceneDiscovery", title:"Scene Discovery", content:"sceneDiscovery", refreshTimeout:5)
+    page(name:"defaultTransition", title:"Default Transition", content:"defaultTransition", refreshTimeout:5)
 }
 
 def mainPage() {
@@ -187,7 +188,7 @@ def sceneDiscovery()
         log.debug "END HUE SCENE DISCOVERY"
 	}
 
-	return dynamicPage(name:"sceneDiscovery", title:"Scene Discovery Started!", nextPage:"", refreshInterval:refreshInterval, install:true, uninstall: true) {
+	return dynamicPage(name:"sceneDiscovery", title:"Scene Discovery Started!", nextPage:"defaultTransition", refreshInterval:refreshInterval, uninstall: true) {
 		section("Please wait while we discover your Hue Scenes. Discovery can take a few minutes, so sit back and relax! Select your device below once discovered.") {
 			input "selectedScenes", "enum", required:false, title:"Select Hue Scenes (${numFoundScenes} found)", multiple:true, options:optionsScenes
 		}
@@ -199,7 +200,26 @@ def sceneDiscovery()
 	}
 }
 
+def defaultTransition()
+{
+	int sceneRefreshCount = !state.sceneRefreshCount ? 0 : state.sceneRefreshCount as int
+	state.sceneRefreshCount = sceneRefreshCount + 1
+	def refreshInterval = 3
 
+	return dynamicPage(name:"defaultTransition", title:"Default Transition", nextPage:"", refreshInterval:refreshInterval, install:true, uninstall: true) {
+		section("Choose how long bulbs should take to transition between on/off and color changes. This can be modified per-device.") {
+			input "selectedTransition", "number", required:true, title:"Transition Time (seconds)", value: 1
+		}
+	}
+}
+
+def getSelectedTransition() {
+	return settings.selectedTransition
+}
+
+int kelvinToMireks(kelvin) {
+	return 1000000 / kelvin //https://en.wikipedia.org/wiki/Mired
+}
 
 private discoverBridges() {
 	sendHubCommand(new physicalgraph.device.HubAction("lan discovery urn:schemas-upnp-org:device:basic:1", physicalgraph.device.Protocol.LAN))


### PR DESCRIPTION
This adds a setting for a default transition time variable, allowing the user to select what they want as default during the initial setup. In my opinion this is preferable to the hard-coded default.
